### PR TITLE
fix: ws link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"liveServer.settings.port": 5501
+}

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1,6 +1,9 @@
 const chat = document.querySelector(".chat");
-const ws = new WebSocket("rs-clone-api-production.up.railway.app:8000");
-
+const ws = new WebSocket("ws://rs-clone-api-production.up.railway.app");
+// const ws = new WebSocket("ws://127.0.0.1:3000");
+ws.onopen = () => {
+  console.log(JSON.stringify("connected!"));
+};
 ws.onmessage = (message) => {
   const messages = JSON.parse(message.data) as Array<{name: string, message: string}>;
 


### PR DESCRIPTION
По идее ссылку менять больше не придётся, на данный момент она: ws://rs-clone-api-production.up.railway.app
![image](https://user-images.githubusercontent.com/95648150/216776167-2483ece7-62ec-423f-aeaf-5ccb210f9d29.png)
